### PR TITLE
chore(grpc): limit gRPC logs to errors

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -299,7 +299,7 @@ func (b *Builder) buildGrpc(c *cadre) (err error) {
 	)
 
 	// replace gRPC logger
-	grpc_zerolog.ReplaceGrpcLoggerV2(*b.logger)
+	grpc_zerolog.ReplaceGrpcLoggerV2(b.logger.Level(zerolog.ErrorLevel))
 
 	// register services
 	// health service


### PR DESCRIPTION
gRPC logs repeated connection attemps (and most other stuff) with INFO log level. It spams logs too much.