### PR TITLE
feat(metrics): Add path key parameter to be exported into metrics.

### DIFF
--- a/builder_http.go
+++ b/builder_http.go
@@ -22,9 +22,8 @@ type httpOptions struct {
 	enableLoggingMiddleware bool
 	enableMetricsMiddleware bool
 
-	globalMiddleware   []gin.HandlerFunc
-	routingGroups      map[string]http.RoutingGroup
-	metricsEndpointKey *string
+	globalMiddleware []gin.HandlerFunc
+	routingGroups    map[string]http.RoutingGroup
 }
 
 func (h *httpOptions) ensure() (err error) {
@@ -45,9 +44,8 @@ func (h *httpOptions) merge(other *httpOptions) (hh *httpOptions, err error) {
 		enableLoggingMiddleware: h.enableLoggingMiddleware,
 		enableMetricsMiddleware: h.enableMetricsMiddleware,
 
-		globalMiddleware:   append(h.globalMiddleware, other.globalMiddleware...),
-		routingGroups:      h.routingGroups,
-		metricsEndpointKey: h.metricsEndpointKey,
+		globalMiddleware: append(h.globalMiddleware, other.globalMiddleware...),
+		routingGroups:    h.routingGroups,
 	}
 
 	for _, othersRoutingGroup := range other.routingGroups {
@@ -65,7 +63,7 @@ func (h *httpOptions) build(cadreContext context.Context, logger zerolog.Logger,
 	{
 		if h.enableMetricsMiddleware {
 			var metricsMiddleware gin.HandlerFunc
-			metricsMiddleware, err = middleware.NewMetrics(metricsRegistry, h.serverName, h.metricsEndpointKey)
+			metricsMiddleware, err = middleware.NewMetrics(metricsRegistry, h.serverName)
 			if err != nil {
 				return
 			}
@@ -196,13 +194,6 @@ func WithoutLoggingMiddleware() HTTPOption {
 func WithoutMetricsMiddleware() HTTPOption {
 	return func(h *httpOptions) error {
 		h.enableMetricsMiddleware = false
-		return nil
-	}
-}
-
-func WithMetricsEndpointKey(metricsEndpointKey string) HTTPOption {
-	return func(h *httpOptions) error {
-		h.metricsEndpointKey = &metricsEndpointKey
 		return nil
 	}
 }

--- a/http/middleware/metrics.go
+++ b/http/middleware/metrics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/moderntv/cadre/metrics"
 )
 
-func NewMetrics(r *metrics.Registry, subsystem string, endpointKey *string) (handler func(*gin.Context), err error) {
+func NewMetrics(r *metrics.Registry, subsystem string) (handler func(*gin.Context), err error) {
 	requestsDuration, err := r.RegisterNewSummaryVec(fmt.Sprintf("http_%v_request_duration_us", subsystem), prometheus.SummaryOpts{
 		Subsystem: subsystem,
 
@@ -41,12 +41,7 @@ func NewMetrics(r *metrics.Registry, subsystem string, endpointKey *string) (han
 		c.Next()
 
 		d := time.Since(t)
-		path := c.FullPath()
-		if endpointKey != nil {
-			parameter := c.Param(*endpointKey)
-			path = parameter
-		}
-
+		path := c.Request.URL.String()
 		requestsCount.WithLabelValues(path, fmt.Sprintf("%v", c.Writer.Status())).Inc()
 		requestsDuration.WithLabelValues(path, fmt.Sprintf("%v", c.Writer.Status())).Observe(float64(d / time.Microsecond))
 	}

--- a/http/middleware/metrics.go
+++ b/http/middleware/metrics.go
@@ -41,7 +41,7 @@ func NewMetrics(r *metrics.Registry, subsystem string) (handler func(*gin.Contex
 		c.Next()
 
 		d := time.Since(t)
-		path := c.Request.URL.String()
+		path := c.Request.URL.Path
 		requestsCount.WithLabelValues(path, fmt.Sprintf("%v", c.Writer.Status())).Inc()
 		requestsDuration.WithLabelValues(path, fmt.Sprintf("%v", c.Writer.Status())).Observe(float64(d / time.Microsecond))
 	}

--- a/http/middleware/metrics.go
+++ b/http/middleware/metrics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/moderntv/cadre/metrics"
 )
 
-func NewMetrics(r *metrics.Registry, subsystem string) (handler func(*gin.Context), err error) {
+func NewMetrics(r *metrics.Registry, subsystem string, endpointKey *string) (handler func(*gin.Context), err error) {
 	requestsDuration, err := r.RegisterNewSummaryVec(fmt.Sprintf("http_%v_request_duration_us", subsystem), prometheus.SummaryOpts{
 		Subsystem: subsystem,
 
@@ -42,6 +42,10 @@ func NewMetrics(r *metrics.Registry, subsystem string) (handler func(*gin.Contex
 
 		d := time.Since(t)
 		path := c.FullPath()
+		if endpointKey != nil {
+			parameter := c.Param(*endpointKey)
+			path = parameter
+		}
 
 		requestsCount.WithLabelValues(path, fmt.Sprintf("%v", c.Writer.Status())).Inc()
 		requestsDuration.WithLabelValues(path, fmt.Sprintf("%v", c.Writer.Status())).Observe(float64(d / time.Microsecond))


### PR DESCRIPTION
Used when using `/:key` endpoints as the generic path was exported

partially solves https://moderntv.atlassian.net/jira/software/c/projects/BACK/boards/76?modal=detail&selectedIssue=BACK-368