### PR TITLE
Fix: file registry watcher slice access panic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,6 +60,7 @@ linters:
             - github.com/cespare/xxhash
             - github.com/hashicorp/consul
             - github.com/google/uuid
+            - github.com/stretchr/testify
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,6 +59,7 @@ linters:
             - github.com/fsnotify/fsnotify
             - github.com/cespare/xxhash
             - github.com/hashicorp/consul
+            - github.com/google/uuid
 
 formatters:
   enable:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-gonic/gin v1.10.0
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/consul/api v1.29.2
 	github.com/moderntv/hashring v1.0.3
@@ -16,6 +17,7 @@ require (
 	github.com/rkollar/go-grpc-middleware v1.2.3-0.20201020153056-bb8b0531b026
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/viper v1.15.0
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/net v0.39.0
 	google.golang.org/grpc v1.71.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -202,7 +204,6 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
 	github.com/tetafro/godot v1.5.1 // indirect

--- a/registry/file/registry_test.go
+++ b/registry/file/registry_test.go
@@ -1,0 +1,68 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/moderntv/cadre/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	aggregatorService = "aggregator"
+	ingestService     = "ingest"
+	apiService        = "api"
+)
+
+func TestFileRegistry(t *testing.T) {
+	fr, err := NewRegistry("./testdata/registry.yaml")
+	require.NoError(t, err)
+
+	t.Run("Instances_AggregatorService_ReturnsServiceInstances", func(t *testing.T) {
+		instances := fr.Instances(ingestService)
+		assert.Len(t, instances, 1)
+		assert.Equal(t,
+			[]registry.Instance{
+				&instance{serviceName: ingestService, addr: "ingest.moderntv.eu"},
+			},
+			instances,
+		)
+	})
+
+	t.Run("Instances_IngestService_ReturnsServiceInstances", func(t *testing.T) {
+		instances := fr.Instances(aggregatorService)
+		assert.Len(t, instances, 3)
+		assert.Equal(t,
+			[]registry.Instance{
+				&instance{serviceName: aggregatorService, addr: "aggregator1.moderntv.eu"},
+				&instance{serviceName: aggregatorService, addr: "aggregator2.moderntv.eu"},
+				&instance{serviceName: aggregatorService, addr: "aggregator3.moderntv.eu"},
+			},
+			instances,
+		)
+	})
+
+	t.Run("Instances_APIService_ReturnsNoInstances", func(t *testing.T) {
+		instances := fr.Instances(apiService)
+		assert.Empty(t, instances)
+	})
+
+	t.Run("Watch_StopMultipleWatchersForSingleService_CorrectlyCleanupsWatchers", func(t *testing.T) {
+		_, stop1 := fr.Watch(ingestService)
+		_, stop2 := fr.Watch(ingestService)
+		_, stop3 := fr.Watch(ingestService)
+
+		fr := fr.(*fileRegistry)
+
+		assert.Len(t, fr.watchers[ingestService], 3)
+
+		stop1()
+		assert.Len(t, fr.watchers[ingestService], 2)
+
+		stop2()
+		assert.Len(t, fr.watchers[ingestService], 1)
+
+		stop3()
+		assert.Empty(t, fr.watchers[ingestService])
+	})
+}

--- a/registry/file/testdata/registry.yaml
+++ b/registry/file/testdata/registry.yaml
@@ -1,0 +1,8 @@
+---
+aggregator:
+  - aggregator1.moderntv.eu
+  - aggregator2.moderntv.eu
+  - aggregator3.moderntv.eu
+
+ingest:
+  - ingest.moderntv.eu

--- a/registry/file/watcher.go
+++ b/registry/file/watcher.go
@@ -1,0 +1,18 @@
+package file
+
+import (
+	"github.com/google/uuid"
+	"github.com/moderntv/cadre/registry"
+)
+
+type watcher struct {
+	id       uuid.UUID
+	changeCh chan registry.RegistryChange
+}
+
+func newWatcher() watcher {
+	return watcher{
+		id:       uuid.New(),
+		changeCh: make(chan registry.RegistryChange),
+	}
+}


### PR DESCRIPTION
When multiple service watchers are registered, they close in a non-deterministic matter. However, they use indexes to
remove themselves from the watchers slice. This caused occasional out of bound access. It is now solved using UUID to
"index" the watchers.