### PR TITLE
Make with logging ignore paths option operate on builder level

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	stdhttp "net/http"
 	"os"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -58,6 +59,9 @@ type Builder struct {
 	prometheusRegistry    *prometheus.Registry
 	metricsHTTPServerAddr string
 	metricsPath           string
+
+	// logging
+	loggingIgnorePatterns []*regexp.Regexp
 
 	grpcOptions *grpcOptions
 	httpOptions []*httpOptions
@@ -406,7 +410,12 @@ func (b *Builder) buildHTTP(
 	}
 
 	for _, httpOptions := range mergedHTTPOptions {
-		httpServers[httpOptions.listeningAddress], err = httpOptions.build(cadreContext, b.logger, b.metrics)
+		httpServers[httpOptions.listeningAddress], err = httpOptions.build(
+			cadreContext,
+			b.logger,
+			b.metrics,
+			b.loggingIgnorePatterns,
+		)
 		if err != nil {
 			return
 		}

--- a/builder_http.go
+++ b/builder_http.go
@@ -21,7 +21,6 @@ type httpOptions struct {
 
 	enableLoggingMiddleware bool
 	enableMetricsMiddleware bool
-	loggingIgnorePatterns   []*regexp.Regexp
 
 	routerOptions      []gin.OptionFunc
 	globalMiddleware   []gin.HandlerFunc
@@ -47,7 +46,6 @@ func (h *httpOptions) merge(other *httpOptions) (hh *httpOptions, err error) {
 
 		enableLoggingMiddleware: h.enableLoggingMiddleware,
 		enableMetricsMiddleware: h.enableMetricsMiddleware,
-		loggingIgnorePatterns:   append(h.loggingIgnorePatterns, other.loggingIgnorePatterns...),
 
 		routerOptions:      append(h.routerOptions, other.routerOptions...),
 		globalMiddleware:   append(h.globalMiddleware, other.globalMiddleware...),
@@ -69,6 +67,7 @@ func (h *httpOptions) build(
 	cadreContext context.Context,
 	logger zerolog.Logger,
 	metricsRegistry *metrics.Registry,
+	loggingIgnorePatterns []*regexp.Regexp,
 ) (httpServer *http.HttpServer, err error) {
 	serverMiddlewares := []gin.HandlerFunc{}
 	{
@@ -84,7 +83,7 @@ func (h *httpOptions) build(
 		}
 
 		if h.enableLoggingMiddleware {
-			serverMiddlewares = append(serverMiddlewares, middleware.NewLogger(logger, h.loggingIgnorePatterns))
+			serverMiddlewares = append(serverMiddlewares, middleware.NewLogger(logger, loggingIgnorePatterns))
 		}
 
 		serverMiddlewares = append(serverMiddlewares, gin.Recovery())
@@ -234,23 +233,6 @@ func WithoutLoggingMiddleware() HTTPOption {
 func WithoutMetricsMiddleware() HTTPOption {
 	return func(h *httpOptions) error {
 		h.enableMetricsMiddleware = false
-		return nil
-	}
-}
-
-// WithLoggingIgnorePaths configures path patterns for which logging should be skipped.
-// Each pattern is a Go regular expression matched against the request URL path.
-func WithLoggingIgnorePaths(patterns ...string) HTTPOption {
-	return func(h *httpOptions) error {
-		for _, p := range patterns {
-			compiled, err := regexp.Compile(p)
-			if err != nil {
-				return fmt.Errorf("failed compiling logging ignore pattern %q: %w", p, err)
-			}
-
-			h.loggingIgnorePatterns = append(h.loggingIgnorePatterns, compiled)
-		}
-
 		return nil
 	}
 }

--- a/builder_options.go
+++ b/builder_options.go
@@ -3,7 +3,9 @@ package cadre
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/moderntv/cadre/metrics"
 	"github.com/moderntv/cadre/status"
@@ -97,6 +99,24 @@ func WithPrometheusRegistry(registry *prometheus.Registry) Option {
 func WithMetricsListeningAddress(serverListeningAddress string) Option {
 	return func(options *Builder) error {
 		options.metricsHTTPServerAddr = serverListeningAddress
+
+		return nil
+	}
+}
+
+// WithLoggingIgnorePaths configures path patterns for which HTTP logging should be skipped.
+// Each pattern is a Go regular expression matched against the request URL path.
+// This applies to all HTTP servers including internal metrics and status servers.
+func WithLoggingIgnorePaths(patterns ...string) Option {
+	return func(options *Builder) error {
+		for _, p := range patterns {
+			compiled, err := regexp.Compile(p)
+			if err != nil {
+				return fmt.Errorf("failed compiling logging ignore pattern %q: %w", p, err)
+			}
+
+			options.loggingIgnorePatterns = append(options.loggingIgnorePatterns, compiled)
+		}
 
 		return nil
 	}


### PR DESCRIPTION
Without this, it is impossible to ignore nested HTTP servers like metrics.